### PR TITLE
Show series list in a particular order

### DIFF
--- a/SeriesTracker/Models/Series.swift
+++ b/SeriesTracker/Models/Series.swift
@@ -35,6 +35,17 @@ class Series {
         return status
     }
     
+    func lastReadBook() -> Date? {
+
+        if let oldestObject = books.min(by: { $0.endDate ?? Date() > $1.endDate ?? Date() }) {
+            print("The oldest object is \(oldestObject.title) with date \(oldestObject.endDate)")
+            return oldestObject.endDate
+        } else {
+            print("The array is empty")
+            return nil
+        }
+    }
+    
 }
   
 

--- a/SeriesTracker/Views/BookListView.swift
+++ b/SeriesTracker/Views/BookListView.swift
@@ -35,9 +35,14 @@ struct BookListView: View {
                                 HStack {
                                     VStack(alignment: .leading) {
                                         Text(book.title)
-                                        Text(book.readStatus.rawValue.capitalized)
-                                            .font(.caption)
-                                            .foregroundColor(.secondary)
+                                        HStack {
+                                            Text(book.readStatus.rawValue.capitalized)
+                                                .font(.caption)
+                                                .foregroundColor(.secondary)
+//                                            Text(book.endDate) // TODO:  Why can't the compiler resolve the endDate.
+//                                                .font(.caption)
+//                                                .foregroundColor(.secondary)
+                                        }
                                     }
                                     Spacer()
                                     Image(systemName: book.readStatus.statusIcon())

--- a/SeriesTracker/Views/SeriesListView.swift
+++ b/SeriesTracker/Views/SeriesListView.swift
@@ -15,15 +15,20 @@ struct SeriesListView: View {
     @State private var newSeriesName = ""
     @State private var createNewSeries = false
     
+    var sortedSeries: [Series] {
+            // Sort the array by date, oldest first
+        series.sorted(by: { $0.lastReadBook() ?? Date() < $1.lastReadBook() ?? Date()  })
+    }
+    
     var body: some View {
         NavigationStack {
             VStack {
-                if series.isEmpty {
+                if sortedSeries.isEmpty {
                     ContentUnavailableView("Enter a book series.", systemImage: "book.fill")
                 } else {
                     List {
                         Section(header: Text("My Book Series")) {
-                            ForEach(series) { bookSeries in
+                            ForEach(sortedSeries) { bookSeries in
                                 NavigationLink(destination: SeriesDetailView(series: bookSeries)) {
                                     SeriesRowView(series: bookSeries)
                                     }


### PR DESCRIPTION
This looks very good.  The only thing it was missing for basic functionality was to show the series list in a particular order.
I wanted the order to be the series with the oldest completion date.  So when I finished I'd go back to the oldest series and pick up the next book (if available).

I think these changes accomplish that.
Look for a TODO:  I can't figure that issue out.