### PR TITLE
Author refactor

### DIFF
--- a/SeriesTracker.xcodeproj/project.pbxproj
+++ b/SeriesTracker.xcodeproj/project.pbxproj
@@ -282,7 +282,7 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 1.0.5;
+				MARKETING_VERSION = 1.0.6;
 				PRODUCT_BUNDLE_IDENTIFIER = net.mjoc.SeriesTracker;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				PROVISIONING_PROFILE_SPECIFIER = "";
@@ -316,7 +316,7 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 1.0.5;
+				MARKETING_VERSION = 1.0.6;
 				PRODUCT_BUNDLE_IDENTIFIER = net.mjoc.SeriesTracker;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				PROVISIONING_PROFILE_SPECIFIER = "";

--- a/SeriesTracker/Models/Author.swift
+++ b/SeriesTracker/Models/Author.swift
@@ -12,6 +12,7 @@ import SwiftData
 class Author: Codable, Hashable {
     var id: UUID
     var name: String
+    //@Attribute(.unique) var name: String   // ← make each name unique in the SQLite schema
     
     init(name: String) {
         self.id = UUID()

--- a/SeriesTracker/Models/Author.swift
+++ b/SeriesTracker/Models/Author.swift
@@ -35,3 +35,7 @@ class Author: Codable, Hashable {
         try container.encode(name, forKey: .name)
     }
 }
+
+struct AuthorDTO : Codable {
+    let name: String
+}

--- a/SeriesTracker/Models/Book.swift
+++ b/SeriesTracker/Models/Book.swift
@@ -67,3 +67,18 @@ class Book: Identifiable, Codable, Hashable {
         try container.encodeIfPresent(author, forKey: .author)
     }
 }
+
+struct BookDTO : Codable {
+    var title: String
+    var seriesOrder: Int
+    var readStatus: ReadStatus
+    var startDate: Date?
+    var endDate: Date?
+    var rating: Int?
+    var notes: String
+    var authorname: String
+//    var series: Series?
+//    var author: Author?
+//    @Attribute(.externalStorage) var bookCover: Data?
+
+}

--- a/SeriesTracker/Models/ModelContext+Authors.swift
+++ b/SeriesTracker/Models/ModelContext+Authors.swift
@@ -24,3 +24,18 @@ extension ModelContext {
         }
     }
 }
+
+extension Bundle {
+    /// CFBundleShortVersionString
+    var appVersion: String {
+        infoDictionary?["CFBundleShortVersionString"] as? String ?? "Unknown"
+    }
+    /// CFBundleVersion
+    var buildNumber: String {
+        infoDictionary?["CFBundleVersion"] as? String ?? "Unknown"
+    }
+    /// e.g. "1.2.3 (45)"
+    var versionNumberString: String {
+        "\(appVersion)"
+    }
+}

--- a/SeriesTracker/Models/ModelContext+Authors.swift
+++ b/SeriesTracker/Models/ModelContext+Authors.swift
@@ -1,0 +1,26 @@
+//
+//  ModelContext+Authors.swift
+//  SeriesTracker
+//
+//  Created by Morgan Jones on 5/4/25.
+//
+
+import SwiftData
+import Foundation
+
+extension ModelContext {
+    func author(named name: String) -> Author {
+        // specify the root type on the key path
+        do {
+            let descriptor = FetchDescriptor<Author> (predicate: #Predicate<Author> { $0.name == name })
+            
+            let existing: [Author] = try fetch(descriptor)
+            if let first = existing.first { return first }
+            let new = Author(name: name)
+            insert(new)
+            return new
+        } catch {
+            fatalError("Unable to fetch author \(name): \(error)")
+        }
+    }
+}

--- a/SeriesTracker/Models/Series.swift
+++ b/SeriesTracker/Models/Series.swift
@@ -52,7 +52,7 @@ class Series: Codable, Hashable, Identifiable {
         name = try container.decodeIfPresent(String.self, forKey: .name) ?? "Untitled"
         books = try container.decodeIfPresent([Book].self, forKey: .books) ?? []
         status = try container.decodeIfPresent(SeriesStatus.self, forKey: .status) ?? .inProgress
-        author = try container.decodeIfPresent(Author.self, forKey: .author) ?? Author(name: "Unknown")
+        author = try container.decodeIfPresent(Author.self, forKey: .author)  ?? Author(name: "Couldn't Decode Series Author, FIX!")
         notes = try container.decodeIfPresent(String.self, forKey: .notes) ?? "" // Default: empty string
     }
     
@@ -83,7 +83,7 @@ class Series: Codable, Hashable, Identifiable {
     }
     
     func lastReadBook() -> Date? {
-        let completedBooks = books.filter({$0.readStatus == .completed})
+//        let completedBooks = books.filter({$0.readStatus == .completed})
 //        for abook in completedBooks {
 //            print("'\(abook.title)' was completed on \(abook.endDate ?? Date.distantFuture)")
 //        }

--- a/SeriesTracker/Models/Series.swift
+++ b/SeriesTracker/Models/Series.swift
@@ -127,10 +127,35 @@ class Series: Codable, Hashable, Identifiable {
     }
     
     static func exportToJSON(series: [Series]) throws -> Data {
+        
+        // Convert to DTO
+        let dtos = series.map { s in
+          SeriesDTO(
+            name: s.name,
+            status: s.status,
+            authorname: s.author.name,
+            notes: s.notes,
+            books: s.books.map { b in
+              BookDTO(
+                title: b.title,
+                seriesOrder: b.seriesOrder,
+                readStatus: b.readStatus,
+                startDate: b.startDate,
+                endDate: b.endDate,
+                rating: b.rating,
+                notes: b.notes,
+                authorname: b.author?.name ?? "No Author")
+            }
+          )
+        }
+        
+        
+        
         let encoder = JSONEncoder()
         encoder.dateEncodingStrategy = .iso8601
         encoder.outputFormatting = .prettyPrinted
-        return try encoder.encode(series)
+        //return try encoder.encode(series)
+        return try encoder.encode(dtos)
     }
     
     static func seriesJSON(series: [Series]) -> Data {
@@ -163,3 +188,12 @@ struct JSONFile: FileDocument {
 
 }
 
+struct SeriesDTO: Codable {
+    var name: String
+//    @Relationship(deleteRule: .cascade) var books: [Book]
+    var status: SeriesStatus
+//    var author: Author
+    var authorname: String
+    var notes: String
+    var books: [BookDTO]
+}

--- a/SeriesTracker/README.md
+++ b/SeriesTracker/README.md
@@ -4,3 +4,16 @@ Far from finished but I believe it to be a good start.
 ![IMG_0818](https://github.com/user-attachments/assets/4a469db3-98b3-4736-a857-2da1ae8f2e40)
 ![IMG_0814 copy](https://github.com/user-attachments/assets/b704f13a-5b70-4df0-b12b-922a0598ad38)
 ![IMG_0816 copy](https://github.com/user-attachments/assets/9d0a650c-9299-43b1-8182-247e1e9ea8f7)
+
+Version History...
+
+starting a bit late.
+
+050425
+1.0.5 - This was the version currently on my phone which worked but had several annoyances I wanted to address
+        1.  Start Date for new books wasn't always working.
+        2.  Authors were duplicated over and over
+        3.  Book and Series status are out of synce
+1.0.6 - This contains refactoring to address duplicate Authors both during creation of new series and books and importing from exported json.  This version marks the end of compatibility of importing 1.0.5 and older .json files.
+        1.  This version also has the fix for the start date
+        3.  Book and series status are still out of date.

--- a/SeriesTracker/SeriesSearchTab/BookRowView.swift
+++ b/SeriesTracker/SeriesSearchTab/BookRowView.swift
@@ -8,6 +8,7 @@
 import SwiftUI
 
 struct BookRowView: View {
+    @Environment(\.modelContext) private var modelContext
     let bookInfo: BookInfo
     @State private var importBook: Bool = false
     
@@ -53,8 +54,9 @@ struct BookRowView: View {
         }
         .padding(.vertical, 8)
         .sheet(isPresented: $importBook) {
-            let authorName = bookInfo.authors?.first ?? "Unknown"
-            let newBook = Book(title: bookInfo.title, author: Author(name: authorName))
+            let authorName = bookInfo.authors?.first ?? "Unknown" // TODO:  How to handle multiple authors...
+            let auth = modelContext.author(named: authorName)
+            let newBook = Book(title: bookInfo.title, author: auth)
             ImportBookView(book: newBook)
         }
     }

--- a/SeriesTracker/SeriesSearchTab/SeriesResultsView.swift
+++ b/SeriesTracker/SeriesSearchTab/SeriesResultsView.swift
@@ -68,8 +68,8 @@ struct SeriesResultsView: View {
         error = nil
         
         do {
-            let encodedSeries = seriesName.addingPercentEncoding(withAllowedCharacters: .urlQueryAllowed) ?? ""
-            let encodedAuthor = authorName.addingPercentEncoding(withAllowedCharacters: .urlQueryAllowed) ?? ""
+            //let encodedSeries = seriesName.addingPercentEncoding(withAllowedCharacters: .urlQueryAllowed) ?? ""
+            //let encodedAuthor = authorName.addingPercentEncoding(withAllowedCharacters: .urlQueryAllowed) ?? ""
             
             //let urlString = "https://www.googleapis.com/books/v1/volumes?q=intitle:\(encodedSeries)+inauthor:\(encodedAuthor)&maxResults=40"
             //let query = "\(seriesName) in title+inauthor:\(authorName)".addingPercentEncoding(withAllowedCharacters: .urlQueryAllowed) ?? ""

--- a/SeriesTracker/Views/BookEditorView.swift
+++ b/SeriesTracker/Views/BookEditorView.swift
@@ -20,7 +20,7 @@ struct BookEditorView: View {
     @State private var title: String = ""
     @State private var seriesOrder: Int = 1
     @State private var selectedAuthor: Author?
-    @State private var author: Author = Author(name: "Not Selected")
+    @State private var author: Author?
     
     @Query(sort: \Author.name) private var authors: [Author]
     
@@ -34,7 +34,7 @@ struct BookEditorView: View {
             buttonName = "Update Book"
             title = existingBook.title
             seriesOrder = existingBook.seriesOrder
-            author = existingBook.author ?? Author(name: "Not Selected")
+            author = existingBook.author
         } else {
             let newBook = Book(title: "")
             _book = State(initialValue: newBook)
@@ -153,8 +153,9 @@ struct BookEditorView: View {
     }
     
     private func addNewAuthor() {
-        let newAuthor = Author(name: newAuthorName)
-        modelContext.insert(newAuthor)
+        let newAuthor = modelContext.author(named: newAuthorName)
+        
+        //modelContext.insert(newAuthor)
         book.author = newAuthor
         newAuthorName = ""
         showingNewAuthorSheet = false

--- a/SeriesTracker/Views/BookListView.swift
+++ b/SeriesTracker/Views/BookListView.swift
@@ -72,7 +72,7 @@ struct BookListView: View {
             }
         }
         .sheet(isPresented: $addingNewBook) {
-            BookEditorView(book: nil, series: series)
+            BookEditorView(series: series)
         }
     }
     

--- a/SeriesTracker/Views/SeriesEditorView.swift
+++ b/SeriesTracker/Views/SeriesEditorView.swift
@@ -24,8 +24,7 @@ struct SeriesEditorView: View {
             isNewSeries = false
         } else {
             // Create a new series with a default author when none is provided
-            let defaultAuthor = Author(name: "")
-            let newSeries = Series(name: "", author: defaultAuthor)
+            let newSeries = Series(name: "", author: Author(name: "Series Author Not Set"))
             _series = State(initialValue: newSeries)
             editorTitle = "Add Series"
             buttonName = "Add Series"
@@ -132,8 +131,9 @@ struct SeriesEditorView: View {
     }
     
     private func addNewAuthor() {
-        let newAuthor = Author(name: newAuthorName)
-        modelContext.insert(newAuthor)
+        let newAuthor = modelContext.author(named: newAuthorName)
+        //let newAuthor = Author(name: newAuthorName)
+        //modelContext.insert(newAuthor)
         series.author = newAuthor
         
         // Reset and dismiss

--- a/SeriesTracker/Views/SeriesEditorView.swift
+++ b/SeriesTracker/Views/SeriesEditorView.swift
@@ -98,6 +98,16 @@ struct SeriesEditorView: View {
     
     private var authorSelectionView: some View {
         Menu {
+            
+            // Add new author option
+            Button(action: {
+                showingNewAuthorSheet = true
+            }) {
+                Label("Add New Author", systemImage: "plus.circle")
+            }
+            
+            Divider()
+
             // Existing authors
             ForEach(authors) { author in
                 Button(action: {
@@ -110,15 +120,6 @@ struct SeriesEditorView: View {
                         }
                     }
                 }
-            }
-            
-            Divider()
-            
-            // Add new author option
-            Button(action: {
-                showingNewAuthorSheet = true
-            }) {
-                Label("Add New Author", systemImage: "plus.circle")
             }
         } label: {
             HStack {

--- a/SeriesTracker/Views/SeriesListView.swift
+++ b/SeriesTracker/Views/SeriesListView.swift
@@ -366,7 +366,10 @@ struct SeriesListView: View {
        print("Checking '\(inSeries.name)'")
         do {
             let seriesName = inSeries.name
-            let authorName = removeDiacritics(inSeries.author.name.lowercased()) //inSeries.author.name
+            var authorName = ""
+            let author = inSeries.author
+            authorName = removeDiacritics(author.name.lowercased()) //inSeries.author.name
+            
 //            let encodedSeries = seriesName.addingPercentEncoding(withAllowedCharacters: .urlQueryAllowed) ?? ""
 //            let encodedAuthor = authorName.addingPercentEncoding(withAllowedCharacters: .urlQueryAllowed) ?? ""
             
@@ -430,7 +433,7 @@ struct SeriesListView: View {
         let waitingForNextBookSeries = series.filter({$0.status == .waitingForNextBook })
         print("\n\n\nChecking for new books... in (\(waitingForNextBookSeries.count)) waiting series")
         for series in waitingForNextBookSeries {
-            await searchForNewBooks(inSeries: series)
+            let _ = await searchForNewBooks(inSeries: series)
         }
 
     }

--- a/SeriesTracker/Views/SeriesListView.swift
+++ b/SeriesTracker/Views/SeriesListView.swift
@@ -192,6 +192,8 @@ struct SeriesListView: View {
                         Button("Import Series") {
                             isImporting = true
                         }
+                        
+                        Button("Version: \(Bundle.main.versionNumberString)") {}
                     } label: {
                         Image(systemName: "ellipsis.circle")
                             .imageScale(.large)
@@ -301,7 +303,7 @@ struct SeriesListView: View {
         }
         .onAppear {
             Task {
-                await checkForNewBooks()
+                // await checkForNewBooks() // TODO:  Uncomment to test async online check for new books... 
             }
         }
     }


### PR DESCRIPTION
OK, this appears to work, but is still pretty down and dirty.
First I added an extension to modelContext.add(named: ...), Bob suggested that use a function list that which would first check for existence, if it already exists return that else create a new one.
Using that method, when creating series/books/authors, authors are not duplicated.

dandy...

then I tried the ole export/import test.   duplicated authors!?

the importing was bypassing my author extension on modelContext, again Bob recommended using DTO's when exporting and importing then using the imported DTO's to recreate all the models USING my extension... this work!?

Shocking...
While it sounds like Bob was very helpful, he spent a good hour or so of my afternoon lying his ass off about SwiftData fetch descriptors... which I could only get to work if I went to google it!!!

Mike, I would look through these changes carefully, before merging... yes it works, but I was modifying stuff pretty haphazardly...  like I'm not sure how my changes effect yourstruct JSONFile: FileDocument { in Series.swift... not sure if that is used anymore?!